### PR TITLE
feat: migrate to AsyncMessageBusClient (FastAPI lifespan, no thread bridge)

### DIFF
--- a/busmon.py
+++ b/busmon.py
@@ -1,19 +1,18 @@
 import asyncio
 import json
+import os
 import secrets
-import threading
-from datetime import datetime
 from contextlib import asynccontextmanager
+from datetime import datetime
 
-from fastapi import FastAPI, WebSocket, Depends, HTTPException, status
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, HTTPException, WebSocket, status
 from fastapi.responses import HTMLResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
-from ovos_bus_client import MessageBusClient, Message
+from ovos_bus_client import Message
+from ovos_bus_client.client import AsyncMessageBusClient
 from ovos_bus_client.session import SessionManager
 from starlette.websockets import WebSocketState
-
-import os
-from dotenv import load_dotenv
 
 load_dotenv()
 
@@ -24,7 +23,6 @@ PASSWORD = os.getenv("PASSWORD", "ovos")
 app = FastAPI()
 security = HTTPBasic()
 websocket_clients = set()
-main_loop = None
 
 IGNORE_LIST = ["ovos.session.update_default"]
 GUI = ["gui.status.request"]
@@ -357,49 +355,69 @@ async def websocket_endpoint(websocket: WebSocket):
         websocket_clients.remove(websocket)
 
 
-def broadcast(message: dict):
-    global main_loop
+async def _broadcast(message: dict) -> None:
+    """Fan out one bus message to every connected websocket client.
+
+    Sends are gathered so a slow/closed client cannot stall the others.
+    """
     data = json.dumps(message)
-    for ws in list(websocket_clients):
-        if main_loop and ws.application_state == WebSocketState.CONNECTED:
-            asyncio.run_coroutine_threadsafe(ws.send_text(data), main_loop)
+    targets = [ws for ws in list(websocket_clients)
+               if ws.application_state == WebSocketState.CONNECTED]
+    if not targets:
+        return
+    await asyncio.gather(
+        *(ws.send_text(data) for ws in targets),
+        return_exceptions=True,
+    )
 
 
-def run_bus_monitor():
-    client = MessageBusClient()
-
-    def echo(msg: str):
-        m: Message = Message.deserialize(msg)
-        sess = SessionManager.get(m)
-        source = m.context.get("source") if m.context else None
-        dest = m.context.get("destination") if m.context else None
-        standalone_keys = ["session", "source", "destination"]
-        message_data = {
-            "timestamp": datetime.now().isoformat(),
-            "type": m.msg_type,
-            "session": sess.session_id,
-            "session_data": sess.serialize(),
-            "source": source,
-            "destination": dest,
-            "context": {k: v for k, v in m.context.items() if k not in standalone_keys} if m.context else {},
-            "data": m.data or {},
-        }
-        broadcast(message_data)
-
-    client.on("message", echo)
-
-    def run_client():
-        client.run_forever()
-
-    threading.Thread(target=run_client, daemon=True).start()
+def _build_message_payload(raw: str) -> dict:
+    """Decode a raw bus frame into the UI-facing dict."""
+    m: Message = Message.deserialize(raw)
+    sess = SessionManager.get(m)
+    source = m.context.get("source") if m.context else None
+    dest = m.context.get("destination") if m.context else None
+    standalone_keys = ["session", "source", "destination"]
+    return {
+        "timestamp": datetime.now().isoformat(),
+        "type": m.msg_type,
+        "session": sess.session_id,
+        "session_data": sess.serialize(),
+        "source": source,
+        "destination": dest,
+        "context": {k: v for k, v in m.context.items()
+                    if k not in standalone_keys} if m.context else {},
+        "data": m.data or {},
+    }
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global main_loop
-    main_loop = asyncio.get_running_loop()
-    run_bus_monitor()
-    yield
+    """Manage the bus-client lifecycle with FastAPI startup/shutdown.
+
+    The async bus client shares FastAPI's event loop, so the previous
+    daemon-thread + `asyncio.run_coroutine_threadsafe` bridge is gone:
+    handlers schedule broadcasts directly on the running loop.
+    """
+    bus = AsyncMessageBusClient()
+
+    def _on_raw(raw: str) -> None:
+        # Handler dispatch on the async client is synchronous (matches the
+        # pyee EventEmitter contract), but we are already on the asyncio
+        # loop — schedule the awaitable broadcast directly.
+        try:
+            payload = _build_message_payload(raw)
+        except Exception:
+            return  # malformed bus frame; nothing to forward
+        asyncio.create_task(_broadcast(payload))
+
+    bus.on("message", _on_raw)
+    await bus.connect()
+    try:
+        yield
+    finally:
+        bus.remove("message", _on_raw)
+        await bus.close()
 
 
 app.router.lifespan_context = lifespan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 dev = [
     "pytest>=7.4",
     "pytest-asyncio>=0.23",
-    "httpx>=0.27",
+    "httpx>=0.27,<1.0",
     "pytest-cov>=4.1",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi>=0.110.1
 uvicorn[standard]>=0.29.0
-ovos-bus-client>=2.0.0a1
+ovos-bus-client[async]>=2.0.0
 python-dotenv>=1.0.0
 sse-starlette>=1.6.5


### PR DESCRIPTION
## Summary

`ovos-busmon` was the textbook *sync-bus-client-in-a-daemon-thread bridged to asyncio via `run_coroutine_threadsafe`* pattern. With `ovos-bus-client` 2.0's `AsyncMessageBusClient` (the `[async]` extra, shipped behind PR #200), the bridge goes away entirely.

This is **the first downstream consumer** of `AsyncMessageBusClient` in production. The new HiveMind sibling `AsyncHiveMessageBusClient` (released last week as `hivemind-bus-client 0.8.0a1`) is unrelated — this PR exercises only the OVOS-side async client.

## What changes

### `busmon.py`

- **Drop**: `threading.Thread`, `asyncio.run_coroutine_threadsafe`, the `main_loop` global. ~10 lines of bridge plumbing gone.
- **Lifespan-managed** `AsyncMessageBusClient`: `await bus.connect()` on FastAPI startup, `await bus.close()` on shutdown. Clean teardown, no orphaned daemon thread on uvicorn reload.
- **`_broadcast(message)`** is now async and `gather()`s per-client sends so a slow/disconnected client can't stall the rest of the fanout.
- The bus message handler stays **synchronous** — that's `AsyncMessageBusClient`'s contract for handler registration (same as `pyee.EventEmitter`). The handler is invoked from the async receive task, so it's already on the running loop. It schedules the broadcast via `asyncio.create_task(_broadcast(payload))` — no thread bridge needed.

### `requirements.txt`

- `ovos-bus-client` → `ovos-bus-client[async]>=2.0.0`

The `[async]` extra pulls in `websockets`. Bare `ovos-bus-client` installs are not touched.

## Smoke test

`fastapi.testclient.TestClient` + a stub bus, verifies:

- Lifespan starts/stops cleanly (`connect` and `close` both awaited).
- `message` handler registered on startup, removed on shutdown.
- `/` (HTTP Basic auth `ovos:ovos`) returns 200 + HTML.
- Bad auth returns 401.
- `/ws` accepts and registers the client in `websocket_clients`.

```
smoke test OK
  connect: 1
  close:   1
  on:      ['message']
  remove:  ['message']
```

## Why this is the right canary

Per the OVOS-async-adoption strategy doc, this is **Step 1** — the lowest-blast-radius consumer to validate `AsyncMessageBusClient` in a real FastAPI app before anything user-facing or production-critical (HiveMind chat bridges) migrates.

The architectural shape — "FastAPI WebSocket server forwarding live bus events to browsers" — is the exact pattern that benefits most from `AsyncMessageBusClient`: the previous bridge code (`run_coroutine_threadsafe`) is a documented source of lost-message and reconnect-edge-case bugs around the thread boundary, and now there's just one event loop.

## Test plan

- [x] FastAPI TestClient smoke test (lifespan + auth + ws accept).
- [ ] Manual: run against a real `ovos-core`, open `/`, fire a `ovos-say-to "what time is it"`, confirm both the utterance and the resulting `speak` event appear in the UI's live stream.
- [ ] Force-disconnect test: kill `ovos-core` mid-session, confirm UI shows reconnecting state, restart core, confirm UI recovers without manual refresh.
- [ ] Docker image build still works (no Dockerfile changes needed; the extra is pulled by `pip install -r requirements.txt`).

Refs: OpenVoiceOS/ovos-bus-client PR #200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized message bus client architecture for improved performance and reliability.

* **Chores**
  * Updated message bus client dependency to version 2.0.0 or higher with async support enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TigreGotico/ovos-busmon/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->